### PR TITLE
fix: repoint repo references from MV-Consulting to mavogel org

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -20,7 +20,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
     ],
     // The name of the secret that has the GitHub PAT for auto-approving PRs with permissions repo, workflow, write:packages
     // Generate a new PAT (https://github.com/settings/tokens/new) and add it to your repo's secrets
-    // NOTE: comes from MV-Consulting Org
+    // NOTE: comes from the mavogel Org
     secret: 'PROJEN_GITHUB_TOKEN',
   },
   dependabot: true,
@@ -79,7 +79,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
 // projen's AutoMerge component hardcodes `delete_head_branch: {}` in the
 // mergify rule with no option to disable it. Strip it from the generated
 // .mergify.yml so Mergify does not delete head branches on merge.
-// see https://github.com/MV-Consulting/s3-cdk-assets-bootstrap/pull/265
+// see https://github.com/mavogel/s3-cdk-assets-bootstrap/pull/265
 project.tryFindObjectFile('.mergify.yml')?.addDeletionOverride(
   'pull_request_rules.0.actions.delete_head_branch',
 );


### PR DESCRIPTION
## Bug

The repo was transferred from `github.com/MV-Consulting/s3-cdk-assets-bootstrap` to `github.com/mavogel/s3-cdk-assets-bootstrap`, but local refs still pointed at the old org.

## Root cause

- `.git/config` `origin` remote still resolved to `git@github.com:MV-Consulting/s3-cdk-assets-bootstrap.git`
- `.projenrc.ts` had two stale `MV-Consulting` comment references (lines 23 and 79)

## Fix

- Repointed the local `origin` remote to `git@github.com:mavogel/s3-cdk-assets-bootstrap.git`
- Updated both stale comments in `.projenrc.ts`

## Verification

- `npx projen build` — exit 0, no self-mutation
- `git fetch origin` against the new remote — succeeds
- `gh run list -R mavogel/s3-cdk-assets-bootstrap` — all recent CI runs green under the new location

Separately checked `mvc-projen`'s mergify-cfg and double-release-pipeline issue: already fixed and merged to its `main` — no change needed there.